### PR TITLE
Update env variable to link to the correct extension id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,5 +117,8 @@ Now you can re-build the theme and just run the debug, you will see your command
 
 ### Contributors
 
-Thank you to all the people who have already contributed to vsc-material-theme!
-<a href="graphs/contributors"><img src="https://opencollective.com/vsc-material-theme/contributors.svg?width=890" /></a>
+Thank you to all the people who have already contributed to vsc-material-but-i-wont-sue-you!
+
+## Attribution
+
+The code in this project was [previously hosted at this url](https://github.com/material-theme/vsc-material-theme), but the original author has wiped all history of it, making it incredibly hard to credit him and the other original contributors. Full credit has been preserved in the git history here to our best ability.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ If you're looking for the deprecated Community Material Theme [you can find it h
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/material-theme/contributors.svg?width=890" /></a>
 
 <p align="center"><a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-5E81AC.svg?style=flat-square"/></a></p>
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,4 +5,4 @@ export const BUILD_FOLDER_PATH = path.resolve('./build');
 export const TS_BUILD_FOLDER_PATH = path.resolve('./dist');
 export const CONFIG_FILE_NAME = 'material-theme.config.json';
 export const USER_CONFIG_FILE_NAME = 'user.material-theme.config.json';
-export const MATERIAL_THEME_EXT_ID = 'equinusocio.vsc-material-theme';
+export const MATERIAL_THEME_EXT_ID = 't3dotgg.vsc-material-theme-but-i-wont-sue-you';


### PR DESCRIPTION
This PR adjusts the following:

- Update the env variable to the correct extension id, this is used in `extensionFolderUri`, there could be issues when both old and new extensions are installed.

- Remove the contributing link from the original author, it's linking to a [404](https://github.com/t3dotgg/vsc-material-but-i-wont-sue-you/blob/main/graphs/contributors), same on the `CONTRIBUTING.md` page

- Added the same attribution message to the `CONTRIBUTING.md` as on the `README.md`

