### PR TITLE
fix: add missing diff line backgrounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-material-theme-but-i-wont-sue-you",
-  "version": "35.0.0",
+  "version": "35.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-material-theme-but-i-wont-sue-you",
-      "version": "35.0.0",
+      "version": "35.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/scripts/generator/color-set.ts
+++ b/scripts/generator/color-set.ts
@@ -467,8 +467,10 @@ export const getColorSet = (theme: ThemeSetting): IColorSet => {
       /**
       * Editor diff editor style
       */
-      'diffEditor.insertedTextBackground': `${theme.scheme.base.cyan}20`,
-      'diffEditor.removedTextBackground': `${theme.scheme.base.pink}20`,
+      'diffEditor.insertedTextBackground': `${theme.scheme.base.cyan}15`,
+      'diffEditor.insertedLineBackground': `${theme.scheme.base.cyan}10`,
+      'diffEditor.removedTextBackground': `${theme.scheme.base.pink}15`,
+      'diffEditor.removedLineBackground': `${theme.scheme.base.pink}10`,
       /**
       * Notifications
       */


### PR DESCRIPTION
This PR adds missing diffEditor line background colors using the theme's existing palette.
Currently, VS Code falls back to default colors, which affects the visibility of newly added or commented lines.

Added:
- `diffEditor.insertedLineBackground`
- `diffEditor.removedLineBackground`

Before:
![Screenshot From 2025-04-13 06-30-38](https://github.com/user-attachments/assets/dfc1012d-c014-4acb-b84b-31cddcc8aa7d)

After:
![Screenshot From 2025-04-13 06-30-13](https://github.com/user-attachments/assets/2a8096b5-935e-4ea5-9014-379e9cc628f1)

This improves visual consistency in the diff editor.